### PR TITLE
Feat apply TDP versioning on branch 2.3

### DIFF
--- a/accumulo-handler/pom.xml
+++ b/accumulo-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/druid-handler/pom.xml
+++ b/druid-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/pom.xml
+++ b/hcatalog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/server-extensions/pom.xml
+++ b/hcatalog/server-extensions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/streaming/pom.xml
+++ b/hcatalog/streaming/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/java-client/pom.xml
+++ b/hcatalog/webhcat/java-client/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/svr/pom.xml
+++ b/hcatalog/webhcat/svr/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hplsql/pom.xml
+++ b/hplsql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-serde/pom.xml
+++ b/itests/custom-serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/pom.xml
+++ b/itests/custom-udfs/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-classloader-udf1/pom.xml
+++ b/itests/custom-udfs/udf-classloader-udf1/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-classloader-udf2/pom.xml
+++ b/itests/custom-udfs/udf-classloader-udf2/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-classloader-util/pom.xml
+++ b/itests/custom-udfs/udf-classloader-util/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-vectorized-badexample/pom.xml
+++ b/itests/custom-udfs/udf-vectorized-badexample/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hcatalog-unit/pom.xml
+++ b/itests/hcatalog-unit/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-blobstore/pom.xml
+++ b/itests/hive-blobstore/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-jmh/pom.xml
+++ b/itests/hive-jmh/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-minikdc/pom.xml
+++ b/itests/hive-minikdc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-unit-hadoop2/pom.xml
+++ b/itests/hive-unit-hadoop2/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-unit/pom.xml
+++ b/itests/hive-unit/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/qtest-accumulo/pom.xml
+++ b/itests/qtest-accumulo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/qtest-spark/pom.xml
+++ b/itests/qtest-spark/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/qtest/pom.xml
+++ b/itests/qtest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/test-serde/pom.xml
+++ b/itests/test-serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/util/pom.xml
+++ b/itests/util/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jdbc-handler/pom.xml
+++ b/jdbc-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-client/pom.xml
+++ b/llap-client/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-common/pom.xml
+++ b/llap-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-ext-client/pom.xml
+++ b/llap-ext-client/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-tez/pom.xml
+++ b/llap-tez/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/metastore/pom.xml
+++ b/metastore/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.apache.hive</groupId>
   <artifactId>hive</artifactId>
-  <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+  <version>2.3.9-1.0</version>
   <packaging>pom</packaging>
 
   <name>Hive</name>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/service-rpc/pom.xml
+++ b/service-rpc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.23/pom.xml
+++ b/shims/0.23/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/scheduler/pom.xml
+++ b/shims/scheduler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spark-client/pom.xml
+++ b/spark-client/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
   </parent>
 
   <groupId>org.apache.hive</groupId>
   <artifactId>spark-client</artifactId>
   <packaging>jar</packaging>
   <name>Spark Remote Client</name>
-  <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+  <version>2.3.9-1.0</version>
 
   <properties>
     <hive.path.to.root>..</hive.path.to.root>

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -1,6 +1,6 @@
 # TDP Hive Notes
 
-The version 2.3.10-TDP-0.1.0-SNAPSHOT of Apache Hive is based on the `branch-2.3` tag of the Apache [repository](https://github.com/apache/hive/tree/branch-2.3).
+The version 2.3.9-1.0 of Apache Hive is based on the `branch-2.3` tag of the Apache [repository](https://github.com/apache/hive/tree/branch-2.3).
 
 **Note**: This is a branch that is only needed for the Spark Dependency. Apache Spark 3.2 depends on version `org.spark-project.hive:2.3.9`.
 

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/vector-code-gen/pom.xml
+++ b/vector-code-gen/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>2.3.10-TDP-0.1.0-SNAPSHOT</version>
+    <version>2.3.9-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
This PR applies validated TDP versioning on branch 2.3-TDP

Changes are:

    modified version from 2.3.10-TDP-0.1.0-SNAPSHOT to 2.3.9-1.0

Compilation has been tested with tdp-builder

Why from 2.3.10... to 2.3.9-1.0 ?

2.3.10-TDP-0.1.0-SNAPSHOT was based on 2.3.10-SNAPSHOT release, which is technically a 2.3.9 with few additional commit.
It means that from TOSIT perspective, this is a 2.3.9 with 1 TOSIT cumulative patch