### PR TITLE
Feat apply tdp versioning 3.1

### DIFF
--- a/accumulo-handler/pom.xml
+++ b/accumulo-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/accumulo-handler/pom.xml
+++ b/accumulo-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/classification/pom.xml
+++ b/classification/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/classification/pom.xml
+++ b/classification/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/druid-handler/pom.xml
+++ b/druid-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/druid-handler/pom.xml
+++ b/druid-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/pom.xml
+++ b/hcatalog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/pom.xml
+++ b/hcatalog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/server-extensions/pom.xml
+++ b/hcatalog/server-extensions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/server-extensions/pom.xml
+++ b/hcatalog/server-extensions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/streaming/pom.xml
+++ b/hcatalog/streaming/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/streaming/pom.xml
+++ b/hcatalog/streaming/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/java-client/pom.xml
+++ b/hcatalog/webhcat/java-client/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/java-client/pom.xml
+++ b/hcatalog/webhcat/java-client/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/svr/pom.xml
+++ b/hcatalog/webhcat/svr/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/svr/pom.xml
+++ b/hcatalog/webhcat/svr/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hplsql/pom.xml
+++ b/hplsql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hplsql/pom.xml
+++ b/hplsql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-serde/pom.xml
+++ b/itests/custom-serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-serde/pom.xml
+++ b/itests/custom-serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/pom.xml
+++ b/itests/custom-udfs/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/pom.xml
+++ b/itests/custom-udfs/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-classloader-udf1/pom.xml
+++ b/itests/custom-udfs/udf-classloader-udf1/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-classloader-udf1/pom.xml
+++ b/itests/custom-udfs/udf-classloader-udf1/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-classloader-udf2/pom.xml
+++ b/itests/custom-udfs/udf-classloader-udf2/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-classloader-udf2/pom.xml
+++ b/itests/custom-udfs/udf-classloader-udf2/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-classloader-util/pom.xml
+++ b/itests/custom-udfs/udf-classloader-util/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-classloader-util/pom.xml
+++ b/itests/custom-udfs/udf-classloader-util/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-vectorized-badexample/pom.xml
+++ b/itests/custom-udfs/udf-vectorized-badexample/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/custom-udfs/udf-vectorized-badexample/pom.xml
+++ b/itests/custom-udfs/udf-vectorized-badexample/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it-custom-udfs</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hcatalog-unit/pom.xml
+++ b/itests/hcatalog-unit/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hcatalog-unit/pom.xml
+++ b/itests/hcatalog-unit/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-blobstore/pom.xml
+++ b/itests/hive-blobstore/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-blobstore/pom.xml
+++ b/itests/hive-blobstore/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-jmh/pom.xml
+++ b/itests/hive-jmh/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-jmh/pom.xml
+++ b/itests/hive-jmh/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-minikdc/pom.xml
+++ b/itests/hive-minikdc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-minikdc/pom.xml
+++ b/itests/hive-minikdc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-unit-hadoop2/pom.xml
+++ b/itests/hive-unit-hadoop2/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-unit-hadoop2/pom.xml
+++ b/itests/hive-unit-hadoop2/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-unit/pom.xml
+++ b/itests/hive-unit/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/hive-unit/pom.xml
+++ b/itests/hive-unit/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -19,14 +19,14 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.hive</groupId>
   <artifactId>hive-it</artifactId>
   <packaging>pom</packaging>
-  <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+  <version>3.1.3-1.0-SNAPSHOT</version>
   <name>Hive Integration - Parent</name>
 
   <properties>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -19,14 +19,14 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.hive</groupId>
   <artifactId>hive-it</artifactId>
   <packaging>pom</packaging>
-  <version>3.1.3-1.0-SNAPSHOT</version>
+  <version>3.1.3-1.0</version>
   <name>Hive Integration - Parent</name>
 
   <properties>

--- a/itests/qtest-accumulo/pom.xml
+++ b/itests/qtest-accumulo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/qtest-accumulo/pom.xml
+++ b/itests/qtest-accumulo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/qtest-druid/pom.xml
+++ b/itests/qtest-druid/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hive-it</artifactId>
     <groupId>org.apache.hive</groupId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/itests/qtest-druid/pom.xml
+++ b/itests/qtest-druid/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hive-it</artifactId>
     <groupId>org.apache.hive</groupId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/itests/qtest-spark/pom.xml
+++ b/itests/qtest-spark/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/qtest-spark/pom.xml
+++ b/itests/qtest-spark/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/qtest/pom.xml
+++ b/itests/qtest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/qtest/pom.xml
+++ b/itests/qtest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/test-serde/pom.xml
+++ b/itests/test-serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/test-serde/pom.xml
+++ b/itests/test-serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/util/pom.xml
+++ b/itests/util/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/itests/util/pom.xml
+++ b/itests/util/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive-it</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jdbc-handler/pom.xml
+++ b/jdbc-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jdbc-handler/pom.xml
+++ b/jdbc-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kryo-registrator/pom.xml
+++ b/kryo-registrator/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hive</artifactId>
     <groupId>org.apache.hive</groupId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hive-kryo-registrator</artifactId>

--- a/kryo-registrator/pom.xml
+++ b/kryo-registrator/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hive</artifactId>
     <groupId>org.apache.hive</groupId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
   </parent>
 
   <artifactId>hive-kryo-registrator</artifactId>

--- a/llap-client/pom.xml
+++ b/llap-client/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-client/pom.xml
+++ b/llap-client/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-common/pom.xml
+++ b/llap-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-common/pom.xml
+++ b/llap-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-ext-client/pom.xml
+++ b/llap-ext-client/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-ext-client/pom.xml
+++ b/llap-ext-client/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-tez/pom.xml
+++ b/llap-tez/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/llap-tez/pom.xml
+++ b/llap-tez/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/metastore/pom.xml
+++ b/metastore/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/metastore/pom.xml
+++ b/metastore/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.apache.hive</groupId>
   <artifactId>hive</artifactId>
-  <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+  <version>3.1.3-1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Hive</name>
@@ -147,7 +147,7 @@
     <guava.version>19.0</guava.version>
     <groovy.version>2.4.11</groovy.version>
     <h2database.version>1.3.166</h2database.version>
-    <hadoop.version>3.1.1-TDP-0.1.0-SNAPSHOT</hadoop.version>
+    <hadoop.version>3.1.1-1.0-SNAPSHOT</hadoop.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>
     <hbase.version>2.0.0-alpha4</hbase.version>
@@ -196,9 +196,9 @@
     <slf4j.version>1.7.10</slf4j.version>
     <ST4.version>4.0.4</ST4.version>
     <storage-api.version>2.7.0</storage-api.version>
-    <tez.version>0.9.1-TDP-0.1.0-SNAPSHOT</tez.version>
+    <tez.version>0.9.1-1.0-SNAPSHOT</tez.version>
     <super-csv.version>2.2.0</super-csv.version>
-    <spark.version>2.3.5-TDP-0.1.0-SNAPSHOT</spark.version>
+    <spark.version>2.3.5-1.0-SNAPSHOT</spark.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>2.11.8</scala.version>
     <tempus-fugit.version>1.1</tempus-fugit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.apache.hive</groupId>
   <artifactId>hive</artifactId>
-  <version>3.1.3-1.0-SNAPSHOT</version>
+  <version>3.1.3-1.0</version>
   <packaging>pom</packaging>
 
   <name>Hive</name>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <guava.version>19.0</guava.version>
     <groovy.version>2.4.11</groovy.version>
     <h2database.version>1.3.166</h2database.version>
-    <hadoop.version>3.1.1-1.0-SNAPSHOT</hadoop.version>
+    <hadoop.version>3.1.1-0.0</hadoop.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>
     <hbase.version>2.0.0-alpha4</hbase.version>
@@ -196,9 +196,9 @@
     <slf4j.version>1.7.10</slf4j.version>
     <ST4.version>4.0.4</ST4.version>
     <storage-api.version>2.7.0</storage-api.version>
-    <tez.version>0.9.1-1.0-SNAPSHOT</tez.version>
+    <tez.version>0.9.1-1.0</tez.version>
     <super-csv.version>2.2.0</super-csv.version>
-    <spark.version>2.3.5-1.0-SNAPSHOT</spark.version>
+    <spark.version>2.3.4-1.0</spark.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>2.11.8</scala.version>
     <tempus-fugit.version>1.1</tempus-fugit.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/service-rpc/pom.xml
+++ b/service-rpc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/service-rpc/pom.xml
+++ b/service-rpc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.23/pom.xml
+++ b/shims/0.23/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.23/pom.xml
+++ b/shims/0.23/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/scheduler/pom.xml
+++ b/shims/scheduler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/scheduler/pom.xml
+++ b/shims/scheduler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spark-client/pom.xml
+++ b/spark-client/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.hive</groupId>
   <artifactId>hive-spark-client</artifactId>
   <packaging>jar</packaging>
   <name>Hive Spark Remote Client</name>
-  <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+  <version>3.1.3-1.0-SNAPSHOT</version>
 
   <properties>
     <hive.path.to.root>..</hive.path.to.root>

--- a/spark-client/pom.xml
+++ b/spark-client/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
   </parent>
 
   <groupId>org.apache.hive</groupId>
   <artifactId>hive-spark-client</artifactId>
   <packaging>jar</packaging>
   <name>Hive Spark Remote Client</name>
-  <version>3.1.3-1.0-SNAPSHOT</version>
+  <version>3.1.3-1.0</version>
 
   <properties>
     <hive.path.to.root>..</hive.path.to.root>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.apache.hive</groupId>
   <artifactId>hive-standalone-metastore</artifactId>
-  <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+  <version>3.1.3-1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Hive Standalone Metastore</name>
 

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.apache.hive</groupId>
   <artifactId>hive-standalone-metastore</artifactId>
-  <version>3.1.3-1.0-SNAPSHOT</version>
+  <version>3.1.3-1.0</version>
   <packaging>jar</packaging>
   <name>Hive Standalone Metastore</name>
 

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -1,6 +1,6 @@
 # TDP Hive Notes
 
-The version 3.1.3-TDP-0.1.0-SNAPSHOT of Apache Hive is based on the `branch-3.1` tag of the Apache [repository](https://github.com/apache/hive/tree/branch-3.1).
+The version 3.1.3-1.0-SNAPSHOT of Apache Hive is based on the `branch-3.1` tag of the Apache [repository](https://github.com/apache/hive/tree/branch-3.1).
 
 ## Jenkinfile
 
@@ -12,7 +12,7 @@ The file `./Jenkinsfile-sample` can be used in a Jenkins / Kubernetes environmen
 mvn clean install -Pdist -DskipTests
 ```
 
-`-Pdist` generates a `.tar.gz` file of the release at `./packaging/target/apache-hive-3.1.3-TDP-0.1.0-SNAPSHOT-bin.tar.gz`.
+`-Pdist` generates a `.tar.gz` file of the release at `./packaging/target/apache-hive-3.1.3-1.0-SNAPSHOT-bin.tar.gz`.
 
 ## Testing parameters
 

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -1,6 +1,6 @@
 # TDP Hive Notes
 
-The version 3.1.3-1.0-SNAPSHOT of Apache Hive is based on the `branch-3.1` tag of the Apache [repository](https://github.com/apache/hive/tree/branch-3.1).
+The version 3.1.3-1.0 of Apache Hive is based on the `branch-3.1` tag of the Apache [repository](https://github.com/apache/hive/tree/branch-3.1).
 
 ## Jenkinfile
 
@@ -12,7 +12,7 @@ The file `./Jenkinsfile-sample` can be used in a Jenkins / Kubernetes environmen
 mvn clean install -Pdist -DskipTests
 ```
 
-`-Pdist` generates a `.tar.gz` file of the release at `./packaging/target/apache-hive-3.1.3-1.0-SNAPSHOT-bin.tar.gz`.
+`-Pdist` generates a `.tar.gz` file of the release at `./packaging/target/apache-hive-3.1.3-1.0-bin.tar.gz`.
 
 ## Testing parameters
 

--- a/tdp/test_notes.txt
+++ b/tdp/test_notes.txt
@@ -9,7 +9,7 @@ org.apache.hadoop.hive.ql.exec.TestExecDriver.testMapRedPlan3
 org.apache.hadoop.hive.ql.exec.TestExecDriver.testMapRedPlan4
 org.apache.hadoop.hive.ql.exec.TestExecDriver.testMapRedPlan5
 org.apache.hadoop.hive.ql.exec.TestExecDriver.testMapRedPlan6
---> JAR does not exist or is not a normal file: /dataclan/hive/ql/.m2/org/apache/hive/hive-exec/3.1.3-TDP-0.1.0/hive-exec-3.1.3-TDP-0.1.0.jar
+--> JAR does not exist or is not a normal file: /dataclan/hive/ql/.m2/org/apache/hive/hive-exec/3.1.3-1.0/hive-exec-3.1.3-1.0.jar
 --> Ok with mvn test / KO with mvn surefire:test
 
 

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/upgrade-acid/pom.xml
+++ b/upgrade-acid/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <!--this module is added to parent pom so that it builds and releases with the reset of Hive-->
     <groupId>org.apache.hive</groupId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <artifactId>hive-upgrade-acid</artifactId>
     <name>Hive Upgrade Acid</name>
     <packaging>jar</packaging>

--- a/upgrade-acid/pom.xml
+++ b/upgrade-acid/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <!--this module is added to parent pom so that it builds and releases with the reset of Hive-->
     <groupId>org.apache.hive</groupId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <artifactId>hive-upgrade-acid</artifactId>
     <name>Hive Upgrade Acid</name>
     <packaging>jar</packaging>

--- a/vector-code-gen/pom.xml
+++ b/vector-code-gen/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/vector-code-gen/pom.xml
+++ b/vector-code-gen/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>3.1.3-1.0-SNAPSHOT</version>
+    <version>3.1.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION

This PR applies validated TDP versioning on branch 3.1-TDP

Changes are:

modified version from 3.1.3-TDP-0.1.0-SNAPSHOT to 3.1.3-1.0

Compilation has been tested with tdp-builder
