### PR TITLE
Feat apply tdp versioning 1.2

### DIFF
--- a/accumulo-handler/pom.xml
+++ b/accumulo-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/accumulo-handler/pom.xml
+++ b/accumulo-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/pom.xml
+++ b/hcatalog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/pom.xml
+++ b/hcatalog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/server-extensions/pom.xml
+++ b/hcatalog/server-extensions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/server-extensions/pom.xml
+++ b/hcatalog/server-extensions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/streaming/pom.xml
+++ b/hcatalog/streaming/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/streaming/pom.xml
+++ b/hcatalog/streaming/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/java-client/pom.xml
+++ b/hcatalog/webhcat/java-client/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/java-client/pom.xml
+++ b/hcatalog/webhcat/java-client/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/svr/pom.xml
+++ b/hcatalog/webhcat/svr/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/svr/pom.xml
+++ b/hcatalog/webhcat/svr/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.hive.hcatalog</groupId>
     <artifactId>hive-hcatalog</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hwi/pom.xml
+++ b/hwi/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hwi/pom.xml
+++ b/hwi/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/metastore/pom.xml
+++ b/metastore/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/metastore/pom.xml
+++ b/metastore/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/odbc/pom.xml
+++ b/odbc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/odbc/pom.xml
+++ b/odbc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.apache.hive</groupId>
   <artifactId>hive</artifactId>
-  <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+  <version>1.2.3-1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Hive</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.apache.hive</groupId>
   <artifactId>hive</artifactId>
-  <version>1.2.3-1.0-SNAPSHOT</version>
+  <version>1.2.3-1.0</version>
   <packaging>pom</packaging>
 
   <name>Hive</name>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.20S/pom.xml
+++ b/shims/0.20S/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.20S/pom.xml
+++ b/shims/0.20S/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.23/pom.xml
+++ b/shims/0.23/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/0.23/pom.xml
+++ b/shims/0.23/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/scheduler/pom.xml
+++ b/shims/scheduler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/shims/scheduler/pom.xml
+++ b/shims/scheduler/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spark-client/pom.xml
+++ b/spark-client/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.hive</groupId>
   <artifactId>spark-client</artifactId>
   <packaging>jar</packaging>
   <name>Spark Remote Client</name>
-  <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+  <version>1.2.3-1.0-SNAPSHOT</version>
 
   <properties>
     <hive.path.to.root>..</hive.path.to.root>

--- a/spark-client/pom.xml
+++ b/spark-client/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
   </parent>
 
   <groupId>org.apache.hive</groupId>
   <artifactId>spark-client</artifactId>
   <packaging>jar</packaging>
   <name>Spark Remote Client</name>
-  <version>1.2.3-1.0-SNAPSHOT</version>
+  <version>1.2.3-1.0</version>
 
   <properties>
     <hive.path.to.root>..</hive.path.to.root>

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -1,6 +1,6 @@
 # TDP Hive Notes
 
-The version 1.2.3-TDP-0.1.0-SNAPSHOT of Apache Hive is based on the `branch-1.2` tag of the Apache [repository](https://github.com/apache/hive/tree/branch-1.2).
+The version 1.2.3-1.0-SNAPSHOT of Apache Hive is based on the `branch-1.2` tag of the Apache [repository](https://github.com/apache/hive/tree/branch-1.2).
 
 **Note**: This is a branch that is only needed for the Spark Dependency. Apache Spark 2.x depends on version `org.spark-project.hive:1.2.1.spark2` which was a fork hosted on the Github of one of Spark's maintainers: https://github.com/JoshRosen/hive/tree/release-1.2.1-spark2.
 

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -1,6 +1,6 @@
 # TDP Hive Notes
 
-The version 1.2.3-1.0-SNAPSHOT of Apache Hive is based on the `branch-1.2` tag of the Apache [repository](https://github.com/apache/hive/tree/branch-1.2).
+The version 1.2.3-1.0 of Apache Hive is based on the `branch-1.2` tag of the Apache [repository](https://github.com/apache/hive/tree/branch-1.2).
 
 **Note**: This is a branch that is only needed for the Spark Dependency. Apache Spark 2.x depends on version `org.spark-project.hive:1.2.1.spark2` which was a fork hosted on the Github of one of Spark's maintainers: https://github.com/JoshRosen/hive/tree/release-1.2.1-spark2.
 

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-TDP-0.1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.hive</groupId>
     <artifactId>hive</artifactId>
-    <version>1.2.3-1.0-SNAPSHOT</version>
+    <version>1.2.3-1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
This PR applies validated TDP versioning on branch 1.2-TDP

Changes are:

modified version from 1.2.3-TDP-0.1.0-SNAPSHOT to 1.2.3-1.0

Compilation has been tested with tdp-builder
